### PR TITLE
Add Counter tests

### DIFF
--- a/src/tests/Counter.test.js
+++ b/src/tests/Counter.test.js
@@ -1,22 +1,32 @@
 // import necessary react testing library helpers here
 // import the Counter component here
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Counter from '../components/Counter';
 
 beforeEach(() => {
   // Render the Counter component here
+  render(<Counter />);
 })
 
 test('renders counter message', () => {
   // Complete the unit test below based on the objective in the line above
+  expect(screen.getByText('Counter')).toBeInTheDocument();
 });
 
 test('should render initial count with value of 0', () => {
   // Complete the unit test below based on the objective in the line above
+  expect(screen.getByTestId('count')).toHaveTextContent('0');
 });
 
-test('clicking + increments the count', () => {
+test('clicking + increments the count', async () => {
   // Complete the unit test below based on the objective in the line above
+  userEvent.click(screen.getByText('+'));
+  expect(screen.getByTestId('count')).toHaveTextContent('1');
 });
 
-test('clicking - decrements the count', () => {
+test('clicking - decrements the count', async () => {
   // Complete the unit test below based on the objective in the line above
+  userEvent.click(screen.getByText('-'));
+  expect(screen.getByTestId('count')).toHaveTextContent('-1');
 });

--- a/src/tests/Counter.test.js
+++ b/src/tests/Counter.test.js
@@ -6,27 +6,24 @@ import Counter from '../components/Counter';
 
 beforeEach(() => {
   // Render the Counter component here
+  // eslint-disable-next-line testing-library/no-render-in-setup
   render(<Counter />);
 })
 
 test('renders counter message', () => {
-  // Complete the unit test below based on the objective in the line above
   expect(screen.getByText('Counter')).toBeInTheDocument();
 });
 
 test('should render initial count with value of 0', () => {
-  // Complete the unit test below based on the objective in the line above
   expect(screen.getByTestId('count')).toHaveTextContent('0');
 });
 
 test('clicking + increments the count', async () => {
-  // Complete the unit test below based on the objective in the line above
   userEvent.click(screen.getByText('+'));
   expect(screen.getByTestId('count')).toHaveTextContent('1');
 });
 
 test('clicking - decrements the count', async () => {
-  // Complete the unit test below based on the objective in the line above
   userEvent.click(screen.getByText('-'));
   expect(screen.getByTestId('count')).toHaveTextContent('-1');
 });


### PR DESCRIPTION
Added tests for Counter component. Tests should have 100% coverage. Note: ESLint has a rule to disallow rendering components in `beforeEach`. It has been agreed upon that this rule may be disabled in this case.